### PR TITLE
Fix custom shotgun rounds not affecting the damage range multiplier

### DIFF
--- a/lua/shotgunbase.lua
+++ b/lua/shotgunbase.lua
@@ -1,3 +1,18 @@
+function ShotgunBase:setup_default()
+	self._damage_near = tweak_data.weapon[self._name_id].damage_near
+	self._damage_far = tweak_data.weapon[self._name_id].damage_far
+	self._rays = tweak_data.weapon[self._name_id].rays or self._ammo_data and self._ammo_data.rays or 12
+	self._range = self._damage_far
+
+	if tweak_data.weapon[self._name_id].use_shotgun_reload == nil then
+		self._use_shotgun_reload = self._use_shotgun_reload or self._use_shotgun_reload == nil
+	else
+		self._use_shotgun_reload = tweak_data.weapon[self._name_id].use_shotgun_reload
+	end
+
+	self._hip_fire_rate_inc = managers.player:upgrade_value("shotgun", "hip_rate_of_fire", 0)
+end
+
 function ShotgunBase:get_damage_falloff(damage, col_ray, user_unit)
 	local distance = col_ray.distance or mvector3.distance(col_ray.unit:position(), user_unit:position())
 	local inc_range_mul = 1

--- a/lua/shotgunbase.lua
+++ b/lua/shotgunbase.lua
@@ -7,3 +7,32 @@ function ShotgunBase:get_damage_falloff(damage, col_ray, user_unit)
 	end
 	return (1 - math.min(1, math.max(0, distance - self._damage_near * inc_range_mul) / (self._damage_far * inc_range_mul))) * damage
 end
+
+function ShotgunBase:_update_stats_values()
+	ShotgunBase.super._update_stats_values(self)
+	self:setup_default()
+
+	if self._ammo_data then
+		if self._ammo_data.rays ~= nil then
+			self._rays = self._ammo_data.rays
+		end
+
+		if self._ammo_data.damage_near ~= nil then
+			self._damage_near = self._ammo_data.damage_near
+		end
+
+		if self._ammo_data.damage_near_mul ~= nil then
+			self._damage_near = self._damage_near * self._ammo_data.damage_near_mul
+		end
+
+		if self._ammo_data.damage_far ~= nil then
+			self._damage_far = self._ammo_data.damage_far
+		end
+
+		if self._ammo_data.damage_far_mul ~= nil then
+			self._damage_far = self._damage_far * self._ammo_data.damage_far_mul
+		end
+
+		self._range = self._damage_far
+	end
+end

--- a/lua/weaponfactorytweakdata.lua
+++ b/lua/weaponfactorytweakdata.lua
@@ -1,14 +1,35 @@
 Hooks:PostHook(WeaponFactoryTweakData, "init", "old_ammo_damage_mul", function(self)
 	self.parts.wpn_fps_upg_a_slug.custom_stats.damage_near_mul = 2
 	self.parts.wpn_fps_upg_a_slug.custom_stats.damage_far_mul = 1.15
-	
+
 	self.parts.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
 	self.parts.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
-	
+
 	self.parts.wpn_fps_upg_a_piercing.custom_stats.damage_near_mul = 2
 	self.parts.wpn_fps_upg_a_piercing.custom_stats.damage_far_mul = 1.7
-	
+
 	self.parts.wpn_fps_upg_a_dragons_breath.custom_stats.damage_near_mul = 2
 	self.parts.wpn_fps_upg_a_dragons_breath.custom_stats.damage_far_mul = 1.15
 	self.parts.wpn_fps_upg_a_dragons_breath.custom_stats.fire_dot_data.dot_trigger_max_distance = 3000
+
+	self.wpn_fps_shot_huntsman.override.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
+	self.wpn_fps_shot_huntsman.override.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
+
+	self.wpn_fps_pis_judge.override.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
+	self.wpn_fps_pis_judge.override.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
+
+	self.wpn_fps_shot_b682.override.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
+	self.wpn_fps_shot_b682.override.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
+
+	self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
+	self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
+
+	self.wpn_fps_sho_coach.override.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
+	self.wpn_fps_sho_coach.override.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
+
+	self.wpn_fps_pis_judge.override.wpn_fps_upg_a_piercing.custom_stats.damage_near_mul = 2
+	self.wpn_fps_pis_judge.override.wpn_fps_upg_a_piercing.custom_stats.damage_far_mul = 1.7
+
+	self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_piercing.custom_stats.damage_near_mul = 2
+	self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_piercing.custom_stats.damage_far_mul = 1.7
 end)

--- a/lua/weaponfactorytweakdata.lua
+++ b/lua/weaponfactorytweakdata.lua
@@ -1,0 +1,14 @@
+Hooks:PostHook(WeaponFactoryTweakData, "init", "old_ammo_damage_mul", function(self)
+	self.parts.wpn_fps_upg_a_slug.custom_stats.damage_near_mul = 2
+	self.parts.wpn_fps_upg_a_slug.custom_stats.damage_far_mul = 1.15
+	
+	self.parts.wpn_fps_upg_a_explosive.custom_stats.damage_near_mul = 2
+	self.parts.wpn_fps_upg_a_explosive.custom_stats.damage_far_mul = 2.5
+	
+	self.parts.wpn_fps_upg_a_piercing.custom_stats.damage_near_mul = 2
+	self.parts.wpn_fps_upg_a_piercing.custom_stats.damage_far_mul = 1.7
+	
+	self.parts.wpn_fps_upg_a_dragons_breath.custom_stats.damage_near_mul = 2
+	self.parts.wpn_fps_upg_a_dragons_breath.custom_stats.damage_far_mul = 1.15
+	self.parts.wpn_fps_upg_a_dragons_breath.custom_stats.fire_dot_data.dot_trigger_max_distance = 3000
+end)

--- a/mod.txt
+++ b/mod.txt
@@ -15,5 +15,6 @@
 		{"hook_id": "lib/units/weapons/newraycastweaponbase", "script_path": "lua/newraycastweaponbase.lua"},
 		{"hook_id": "lib/units/weapons/shotgun/shotgunbase", "script_path": "lua/shotgunbase.lua"},
 		{"hook_id": "lib/tweak_data/weapontweakdata", "script_path": "lua/weapontweakdata.lua"},
+		{"hook_id": "lib/tweak_data/weaponfactorytweakdata", "script_path": "lua/weaponfactorytweakdata.lua"}
 	]
 }


### PR DESCRIPTION
Fixed the custom shotgun rounds not affecting the damage range multiplier and restored their old multipliers.

Also restored the DB rounds trigger distance.